### PR TITLE
Corrected absolute post URL in removeBundles()

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/domain.jsp
+++ b/src/main/webapp/WEB-INF/jsp/domain.jsp
@@ -219,7 +219,7 @@
                      bundles = bundles.substr(0, bundles.length-4);
                     var data = {bundles: bundles };
                     console.log(data);                    
-                    $.post('/domain/removeBundles', data, function(data) {
+                    $.post('domain/removeBundles', data, function(data) {
                                  window.location.reload();             
                     });
                     


### PR DESCRIPTION
Updated `/domain/removeBundles`  to be a relative URL so that it can remain under the /config-ui/ directory.

When clicking the `Remove Selected` button:
![image](https://user-images.githubusercontent.com/15116565/155601061-e8fb847d-0a78-4f47-a232-27beca6809af.png)

The `/domain/` target results in a 404 error.
![image](https://user-images.githubusercontent.com/15116565/155601146-21fdcb11-3d50-4062-b8ef-32f41fc90d95.png)

Removing the leading `/` from the .post target results in a successful operation:
![image](https://user-images.githubusercontent.com/15116565/155601409-d5c1ea43-6cc3-4689-b5ea-da96b5fc699c.png)

